### PR TITLE
Fix undefined offset in observer when the cookie is empty

### DIFF
--- a/src/Model/Observer.php
+++ b/src/Model/Observer.php
@@ -96,7 +96,7 @@ class Elgentos_ServerSideAnalytics_Model_Observer
         $gaCookie = explode('.', Mage::getModel('core/cookie')
                 ->get('_ga'));
 
-        if (empty($gaCookie)) {
+        if (empty($gaCookie) || count($gaCookie) < 4) {
             return;
         }
 


### PR DESCRIPTION
When using an adblocker/tracker protection like uBlock the cookie check will show a notice. 

This happens when you try to call `list()` (with 4 args.) on the `$gaCookie` while the content of $gaCookie is `array(0 => "");`.

Tested on Magento 1.9.3.6.