### PR TITLE
Implement debug mode and logging option and send document path

### DIFF
--- a/src/Model/GAClient.php
+++ b/src/Model/GAClient.php
@@ -21,7 +21,7 @@ class Elgentos_ServerSideAnalytics_Model_GAClient {
         /** @var Analytics analytics */
         $this->analytics = new Analytics(true);
 
-        if (Mage::getIsDeveloperMode() || Mage::getIsDeveloperMode('google/analytics/serverside_debug')) {
+        if (Mage::getIsDeveloperMode() || Mage::getStoreConfigFlag('google/analytics/serverside_debug')) {
             // $this->analytics = new Analytics(true, true); // for dev/staging envs where dev mode is off but we don't want to send events
             $this->analytics->setDebug(true);
         }
@@ -127,7 +127,7 @@ class Elgentos_ServerSideAnalytics_Model_GAClient {
             ->sendEvent();
 
         // @codingStandardsIgnoreStart
-        if (Mage::getIsDeveloperMode() || Mage::getIsDeveloperMode('google/analytics/serverside_debug')) {
+        if (Mage::getIsDeveloperMode() || Mage::getStoreConfigFlag('google/analytics/serverside_debug')) {
             Mage::log(print_r($response->getDebugResponse(), true), null, 'elgentos_serversideanalytics_debug_response.log');
         }
         // @codingStandardsIgnoreEnd

--- a/src/Model/GAClient.php
+++ b/src/Model/GAClient.php
@@ -21,7 +21,7 @@ class Elgentos_ServerSideAnalytics_Model_GAClient {
         /** @var Analytics analytics */
         $this->analytics = new Analytics(true);
 
-        if (Mage::getIsDeveloperMode()) {
+        if (Mage::getIsDeveloperMode() || Mage::getIsDeveloperMode('google/analytics/serverside_debug')) {
             // $this->analytics = new Analytics(true, true); // for dev/staging envs where dev mode is off but we don't want to send events
             $this->analytics->setDebug(true);
         }
@@ -127,7 +127,7 @@ class Elgentos_ServerSideAnalytics_Model_GAClient {
             ->sendEvent();
 
         // @codingStandardsIgnoreStart
-        if (Mage::getIsDeveloperMode()) {
+        if (Mage::getIsDeveloperMode() || Mage::getIsDeveloperMode('google/analytics/serverside_debug')) {
             Mage::log(print_r($response->getDebugResponse(), true), null, 'elgentos_serversideanalytics_debug_response.log');
         }
         // @codingStandardsIgnoreEnd

--- a/src/Model/GAClient.php
+++ b/src/Model/GAClient.php
@@ -4,7 +4,8 @@ use TheIconic\Tracking\GoogleAnalytics\Analytics;
 
 class Elgentos_ServerSideAnalytics_Model_GAClient {
 
-    const GOOGLE_ANALYTICS_SERVERSIDE_DEBUG = 'google/analytics/serverside_debug';
+    const GOOGLE_ANALYTICS_SERVERSIDE_DEBUG_MODE     = 'google/analytics/debug_mode';
+    const GOOGLE_ANALYTICS_SERVERSIDE_ENABLE_LOGGING = 'google/analytics/enable_logging';
 
     /* Analytics object which holds transaction data */
     protected $analytics;
@@ -23,7 +24,7 @@ class Elgentos_ServerSideAnalytics_Model_GAClient {
         /** @var Analytics analytics */
         $this->analytics = new Analytics(true);
 
-        if (Mage::getIsDeveloperMode() || Mage::getStoreConfigFlag(self::GOOGLE_ANALYTICS_SERVERSIDE_DEBUG)) {
+        if (Mage::getIsDeveloperMode() || Mage::getStoreConfigFlag(self::GOOGLE_ANALYTICS_SERVERSIDE_DEBUG_MODE)) {
             // $this->analytics = new Analytics(true, true); // for dev/staging envs where dev mode is off but we don't want to send events
             $this->analytics->setDebug(true);
         }
@@ -129,8 +130,12 @@ class Elgentos_ServerSideAnalytics_Model_GAClient {
             ->sendEvent();
 
         // @codingStandardsIgnoreStart
-        if (Mage::getIsDeveloperMode() || Mage::getStoreConfigFlag(self::GOOGLE_ANALYTICS_SERVERSIDE_DEBUG)) {
+        if (Mage::getIsDeveloperMode() || Mage::getStoreConfigFlag(self::GOOGLE_ANALYTICS_SERVERSIDE_DEBUG_MODE)) {
             Mage::log(print_r($response->getDebugResponse(), true), null, 'elgentos_serversideanalytics_debug_response.log');
+        }
+
+        if (Mage::getStoreConfigFlag(self::GOOGLE_ANALYTICS_SERVERSIDE_ENABLE_LOGGING)) {
+            Mage::log($response->getRequestUrl(), null, 'elgentos_serversideanalytics_requests.log');
         }
         // @codingStandardsIgnoreEnd
     }

--- a/src/Model/GAClient.php
+++ b/src/Model/GAClient.php
@@ -18,6 +18,7 @@ class Elgentos_ServerSideAnalytics_Model_GAClient {
      */
     public function __construct()
     {
+        /** @var Analytics analytics */
         $this->analytics = new Analytics(true);
 
         if (Mage::getIsDeveloperMode()) {
@@ -29,10 +30,10 @@ class Elgentos_ServerSideAnalytics_Model_GAClient {
     }
 
     /**
-     * @param $data
+     * @param Varien_Object $data
      * @throws Exception
      */
-    public function setTrackingData($data)
+    public function setTrackingData(Varien_Object $data)
     {
         if (!$data->getTrackingId()) {
             throw new Exception ('No tracking ID set for GA client.');
@@ -56,6 +57,10 @@ class Elgentos_ServerSideAnalytics_Model_GAClient {
 
         if ($data->getUserAgentOverride()) {
             $this->analytics->setUserAgentOverride($data->getUserAgentOverride());
+        }
+
+        if ($data->getDocumentPath()) {
+            $this->analytics->setDocumentPath($data->getDocumentPath());
         }
     }
 

--- a/src/Model/GAClient.php
+++ b/src/Model/GAClient.php
@@ -4,6 +4,8 @@ use TheIconic\Tracking\GoogleAnalytics\Analytics;
 
 class Elgentos_ServerSideAnalytics_Model_GAClient {
 
+    const GOOGLE_ANALYTICS_SERVERSIDE_DEBUG = 'google/analytics/serverside_debug';
+
     /* Analytics object which holds transaction data */
     protected $analytics;
 
@@ -21,7 +23,7 @@ class Elgentos_ServerSideAnalytics_Model_GAClient {
         /** @var Analytics analytics */
         $this->analytics = new Analytics(true);
 
-        if (Mage::getIsDeveloperMode() || Mage::getStoreConfigFlag('google/analytics/serverside_debug')) {
+        if (Mage::getIsDeveloperMode() || Mage::getStoreConfigFlag(self::GOOGLE_ANALYTICS_SERVERSIDE_DEBUG)) {
             // $this->analytics = new Analytics(true, true); // for dev/staging envs where dev mode is off but we don't want to send events
             $this->analytics->setDebug(true);
         }
@@ -127,7 +129,7 @@ class Elgentos_ServerSideAnalytics_Model_GAClient {
             ->sendEvent();
 
         // @codingStandardsIgnoreStart
-        if (Mage::getIsDeveloperMode() || Mage::getStoreConfigFlag('google/analytics/serverside_debug')) {
+        if (Mage::getIsDeveloperMode() || Mage::getStoreConfigFlag(self::GOOGLE_ANALYTICS_SERVERSIDE_DEBUG)) {
             Mage::log(print_r($response->getDebugResponse(), true), null, 'elgentos_serversideanalytics_debug_response.log');
         }
         // @codingStandardsIgnoreEnd

--- a/src/Model/Observer.php
+++ b/src/Model/Observer.php
@@ -27,14 +27,17 @@ class Elgentos_ServerSideAnalytics_Model_Observer
             return;
         }
 
+        /** @var Elgentos_ServerSideAnalytics_Model_GAClient $client */
         $client = Mage::getModel('elgentos_serversideanalytics/gAClient');
 
         try {
             $trackingDataObject = new Varien_Object([
-                'tracking_id' => Mage::getStoreConfig(Mage_GoogleAnalytics_Helper_Data::XML_PATH_ACCOUNT),
-                'client_id' => $order->getGaUserId(),
-                'ip_override' => $order->getRemoteIp()
+                'tracking_id'   => Mage::getStoreConfig(Mage_GoogleAnalytics_Helper_Data::XML_PATH_ACCOUNT),
+                'client_id'     => $order->getGaUserId(),
+                'ip_override'   => $order->getRemoteIp(),
+                'document_path' => '/checkout/onepage/success/'
             ]);
+
             Mage::dispatchEvent('elgentos_serversideanalytics_tracking_data_transport_object', ['tracking_data_object' => $trackingDataObject]);
             $client->setTrackingData($trackingDataObject);
 

--- a/src/etc/system.xml
+++ b/src/etc/system.xml
@@ -5,15 +5,26 @@
             <groups>
                 <analytics>
                     <fields>
-                        <serverside_debug translate="label">
-                            <label>Debug Server Side Synchronisation</label>
+                        <debug_mode translate="label">
+                            <label>Enable Debug Mode</label>
+                            <comment><![CDATA[<strong>Warning:</strong> When this is enabled, transactions will not be pushed to Google Analytics, only debugged]]></comment>
                             <frontend_type>select</frontend_type>
                             <source_model>adminhtml/system_config_source_yesno</source_model>
                             <sort_order>200</sort_order>
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>1</show_in_store>
-                        </serverside_debug>
+                        </debug_mode>
+                        <enable_logging translate="label">
+                            <label>Enable Logging</label>
+                            <comment><![CDATA[When enabled, this will log the requests done to Google Analytics]]></comment>
+                            <frontend_type>select</frontend_type>
+                            <source_model>adminhtml/system_config_source_yesno</source_model>
+                            <sort_order>200</sort_order>
+                            <show_in_default>1</show_in_default>
+                            <show_in_website>1</show_in_website>
+                            <show_in_store>1</show_in_store>
+                        </enable_logging>
                     </fields>
                 </analytics>
             </groups>

--- a/src/etc/system.xml
+++ b/src/etc/system.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0"?>
+<config>
+    <sections>
+        <google>
+            <groups>
+                <analytics>
+                    <fields>
+                        <serverside_debug translate="label">
+                            <label>Debug Server Side Synchronisation</label>
+                            <frontend_type>select</frontend_type>
+                            <source_model>adminhtml/system_config_source_yesno</source_model>
+                            <sort_order>200</sort_order>
+                            <show_in_default>1</show_in_default>
+                            <show_in_website>1</show_in_website>
+                            <show_in_store>1</show_in_store>
+                        </serverside_debug>
+                    </fields>
+                </analytics>
+            </groups>
+        </google>
+    </sections>
+</config>


### PR DESCRIPTION
It's now possible to also enable debug mode on production for more insights. There's also a logging option now, so you can get more information on the synced data.

And we also send the document path, just to be sure.